### PR TITLE
added new sort by reversed base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This means you cannot move any bookmarks in the same folder, unless it is moved 
 
 **Sort Criteria:**
 
-* **Sort By:** allow to specify the first sort criteria, that is to say, the order that will be used to sort the bookmarks The choices are : name, url, description, keyword, date added, last modified, last visited and visited count.
+* **Sort By:** allow to specify the first sort criteria, that is to say, the order that will be used to sort the bookmarks The choices are : name, url, description, keyword, date added, last modified, last visited, visited count and reversed base-URL.
 * **Inverse Order:** if this option is enabled, the order specified in "Sort By" will be reversed. So the order will be descending.
 * **Then Sort By:** allow to specify a second sort criteria (optional). For instance, if the first sort criteria is the name, it is possible to choose a second sort criteria to sort bookmarks with the same name.
 * **Inverse Second Order:** if this option is enabled, the order specified in "Then Sort By" will be reversed.

--- a/lib/bookmark-sorter.js
+++ b/lib/bookmark-sorter.js
@@ -26,6 +26,33 @@ const { Class } = require('sdk/core/heritage'),
     { Folder, menuFolder, Separator, toolbarFolder, unsortedFolder } = require('bookmarks'),
     { Thread } = require('thread');
 
+
+/**
+ * Reverse the base of an URL to do a better sorting
+ */
+let reverseBaseUrl = function(str) {
+	if(str === undefined || !str) {
+		return ""
+	}
+	/* Used code generator: https://regex101.com/ */
+	console.log(str)
+	str = str.replace(/^\S+:\/\//, "");
+	console.log(str)
+	var re = /^[^\/]+$|^[^\/]+/;
+	var m;
+	 
+	if ((m = re.exec(str)) !== null) {
+			if (m.index === re.lastIndex) {
+					re.lastIndex++;
+			}
+			// replace the found string by it's reversion
+			str = str.replace(m[0], m[0].split('.').reverse().join('.'));
+	}
+	console.log(str)
+	return str
+}
+
+
 /**
  * Bookmark sorter class.
  */
@@ -50,6 +77,10 @@ let BookmarkSorter = new Class({
             'caseFirst': 'upper',
             'numeric': true
         };
+				if('revurl' == BookmarkSorter.prototype.firstSortCriteria) {
+					bookmark1['revurl'] = reverseBaseUrl(bookmark1["url"]);
+					bookmark2['revurl'] = reverseBaseUrl(bookmark2["url"]);
+				}
         if(['title', 'url', 'revurl', 'description', 'keyword'].indexOf(BookmarkSorter.prototype.firstSortCriteria) !== -1) {
             result = bookmark1[BookmarkSorter.prototype.firstSortCriteria].localeCompare(bookmark2[BookmarkSorter.prototype.firstSortCriteria], undefined, compareOptions) * BookmarkSorter.prototype.firstReverse;
         }

--- a/lib/bookmark-sorter.js
+++ b/lib/bookmark-sorter.js
@@ -50,14 +50,14 @@ let BookmarkSorter = new Class({
             'caseFirst': 'upper',
             'numeric': true
         };
-        if(['title', 'url', 'description', 'keyword'].indexOf(BookmarkSorter.prototype.firstSortCriteria) !== -1) {
+        if(['title', 'url', 'revurl', 'description', 'keyword'].indexOf(BookmarkSorter.prototype.firstSortCriteria) !== -1) {
             result = bookmark1[BookmarkSorter.prototype.firstSortCriteria].localeCompare(bookmark2[BookmarkSorter.prototype.firstSortCriteria], undefined, compareOptions) * BookmarkSorter.prototype.firstReverse;
         }
         else {
             result = (bookmark1[BookmarkSorter.prototype.firstSortCriteria] - bookmark2[BookmarkSorter.prototype.firstSortCriteria]) * BookmarkSorter.prototype.firstReverse;
         }
         if(result === 0 && BookmarkSorter.prototype.secondSortCriteria !== undefined) {
-            if(['title', 'url', 'description', 'keyword'].indexOf(BookmarkSorter.prototype.secondSortCriteria) !== -1) {
+            if(['title', 'url', 'revurl', 'description', 'keyword'].indexOf(BookmarkSorter.prototype.secondSortCriteria) !== -1) {
                 result = bookmark1[BookmarkSorter.prototype.secondSortCriteria].localeCompare(bookmark2[BookmarkSorter.prototype.secondSortCriteria], undefined, compareOptions) * BookmarkSorter.prototype.secondReverse;
             }
             else {

--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -33,6 +33,7 @@ const { Cc, Ci, Cu } = require('chrome'),
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm', this);
 
+
 /**
  * Item class. Base class for bookmarks/folders/separators/live bookmarks/smart bookmarks.
  */
@@ -165,7 +166,6 @@ let Bookmark = new Class({
         this.title = title;
 				this.url
         this.url = url !== undefined ? url : '';
-				this.revurl = this.__reverseBaseUrl(this.url)
         this.lastVisited = lastVisited;
         this.accessCount = accessCount !== undefined ? accessCount : 0;
         this.dateAdded = dateAdded;
@@ -174,23 +174,6 @@ let Bookmark = new Class({
         this.description = getDescription(this);
         this.setKeyword();
     },
-		/**
-		 * Reverse the base of an URL to do a better sorting
-		 */
-		__reverseBaseUrl: function(str) {
-			/* Used code generator: https://regex101.com/ */
-			var re = /\/\/\S+?(?=\/)/i; 
-			var m;
-			 
-			if ((m = re.exec(str)) !== null) {
-					if (m.index === re.lastIndex) {
-							re.lastIndex++;
-					}
-					// replace the found string by it's reversion
-					m[0] = m[0].replace("//", "");
-					return str.replace(m[0], m[0].split('').reverse().join(''));
-			}
-		},
     /**
      * Fetch the keyword and set it to the current bookmark.
      */

--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -163,7 +163,9 @@ let Bookmark = new Class({
     initialize: function(itemID, index, parentID, title, dateAdded, lastModified, url, lastVisited, accessCount) {
         Item.prototype.initialize.call(this, itemID, index, parentID);
         this.title = title;
+				this.url
         this.url = url !== undefined ? url : '';
+				this.revurl = this.__reverseBaseUrl(this.url)
         this.lastVisited = lastVisited;
         this.accessCount = accessCount !== undefined ? accessCount : 0;
         this.dateAdded = dateAdded;
@@ -172,6 +174,23 @@ let Bookmark = new Class({
         this.description = getDescription(this);
         this.setKeyword();
     },
+		/**
+		 * Reverse the base of an URL to do a better sorting
+		 */
+		__reverseBaseUrl: function(str) {
+			/* Used code generator: https://regex101.com/ */
+			var re = /\/\/\S+?(?=\/)/i; 
+			var m;
+			 
+			if ((m = re.exec(str)) !== null) {
+					if (m.index === re.lastIndex) {
+							re.lastIndex++;
+					}
+					// replace the found string by it's reversion
+					m[0] = m[0].replace("//", "");
+					return str.replace(m[0], m[0].split('').reverse().join(''));
+			}
+		},
     /**
      * Fetch the keyword and set it to the current bookmark.
      */

--- a/lib/main.js
+++ b/lib/main.js
@@ -71,6 +71,7 @@ const _ = require('sdk/l10n').get,
         'lastModified',
         'lastVisited',
         'accessCount'
+				'revurl',
     ];
 
 let customizeObserver = new CustomizeObserver(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -70,8 +70,8 @@ const _ = require('sdk/l10n').get,
         'dateAdded',
         'lastModified',
         'lastVisited',
-        'accessCount'
-				'revurl',
+        'accessCount',
+				'revurl'
     ];
 
 let customizeObserver = new CustomizeObserver(),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "icon": "data/icon-48.png",
     "name": "autosortbookmarks",
     "translators": ["Antoni Boucher"],
-    "version": "2.7",
+    "version": "2.7a",
     "preferences": [
         {
             "name": "auto_sort",
@@ -133,6 +133,10 @@
                 {
                     "value": "7",
                     "label": "Visited count"
+                },
+                {
+                    "value": "8",
+                    "label": "Reversed URL"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
                 {
                     "value": "7",
                     "label": "Visited count"
+                },
+                {
+                    "value": "8",
+                    "label": "Reversed URL"
                 }
             ]
         },

--- a/test/test-bookmark-sorter.js
+++ b/test/test-bookmark-sorter.js
@@ -1770,4 +1770,59 @@ exports.testSortByURL = function(assert, done) {
     });
 };
 
+exports.testSortByRevURL = function(assert, done) {
+    spawn(function() {
+        deleteAllBookmarks();
+        
+        let bookmarkSorter = new BookmarkSorter();
+        bookmarkSorter.setCriteria('revurl', false, undefined, false);
+        
+        let folder = createFolder('Folder', menuFolder);
+        
+        let bookmark1 = createBookmark('Title', 'http://dev.title.com/', folder);
+        let bookmark2 = createBookmark('Test', 'http://www.test.com/', folder);
+        let bookmark3 = createBookmark('Abc', 'http://abc.com/', folder);
+        
+        yield bookmarkSorter.sortFolders(folder);
+        assertBookmarksArray(assert, folder.getChildren()[0], [bookmark3, bookmark2, bookmark1]);
+        assert.strictEqual(folder.getChildren().length, 1);
+        
+        let bookmark4 = createBookmark('Nice test', 'http://nice.com/', folder);
+        
+        yield bookmarkSorter.sortFolders(folder);
+        assertBookmarksArray(assert, folder.getChildren()[0], [bookmark3, bookmark4, bookmark2, bookmark1]);
+        assert.strictEqual(folder.getChildren().length, 1);
+        
+        let bookmark5 = createBookmark('Nice example', 'http://www.example.com/', folder);
+        
+        yield bookmarkSorter.sortFolders(folder);
+        assertBookmarksArray(assert, folder.getChildren()[0], [bookmark3, bookmark5, bookmark4, bookmark2, bookmark1]);
+        assert.strictEqual(folder.getChildren().length, 1);
+        
+        createSeparator(folder);
+        let bookmark6 = createBookmark('Testing', 'http://testing.com/', folder);
+        
+        yield bookmarkSorter.sortFolders(folder);
+        assertBookmarksArray(assert, folder.getChildren()[0], [bookmark3, bookmark5, bookmark4, bookmark2, bookmark1]);
+        assertBookmarksArray(assert, folder.getChildren()[1], [bookmark6]);
+        assert.strictEqual(folder.getChildren().length, 2);
+        
+        let bookmark7 = createBookmark('Nice test', 'http://www.nice.com/', folder);
+        
+        createSeparator(folder);
+        let bookmark8 = createBookmark('Test', 'http://test.com/', folder);
+        let bookmark9 = createBookmark('Abc', 'http://www.abc.com/', folder);
+        
+        yield bookmarkSorter.sortFolders(folder);
+        assertBookmarksArray(assert, folder.getChildren()[0], [bookmark3, bookmark5, bookmark4, bookmark2, bookmark1]);
+        assertBookmarksArray(assert, folder.getChildren()[1], [bookmark7, bookmark6]);
+        assertBookmarksArray(assert, folder.getChildren()[2], [bookmark9, bookmark8]);
+        assert.strictEqual(folder.getChildren().length, 3);
+        
+        resetPreferences();
+        
+        done();
+    });
+};
+
 require('sdk/test').run(exports);


### PR DESCRIPTION
Attention, this is not tested yet. I need to install the Addon SDK as soon as I am home.
**edit**: It is tested now.

eg. these  urls where previously sorted like this:
* "http://banana.com/spam"
* "http://web2.salami.org/foobar"
* "http://www.banana.com/spam?with=eggs"
* "http://www.salami.org/spam"

Mixing "banana" and "salami" because of subdomains was not useful. Now take
this:
* "http://banana.com/spam"
* "http://www.banana.com/spam?with=eggs"
* "http://web2.salami.org/foobar"
* "http://www.salami.org/spam"

That looks better, doesn't it? It's what I call the new sort by reversed base url.